### PR TITLE
Use composer bin-dir

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,6 @@
         "symfony/var-dumper": "~2.8|~3.0",
         "composer/composer": "^1.2"
     },
-    "scripts": {
-        "pre-update-cmd": "Hexanet\\PhpGitHooks\\Composer\\InstallHooksScript::installHooks",
-        "pre-install-cmd": "Hexanet\\PhpGitHooks\\Composer\\InstallHooksScript::installHooks"
-    },
     "config": {
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,13 @@
         "symfony/var-dumper": "~2.8|~3.0",
         "composer/composer": "^1.2"
     },
+    "scripts": {
+        "pre-update-cmd": "Hexanet\\PhpGitHooks\\Composer\\InstallHooksScript::installHooks",
+        "pre-install-cmd": "Hexanet\\PhpGitHooks\\Composer\\InstallHooksScript::installHooks"
+    },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "bin-dir": "bin/"
     },
     "bin": ["bin/php-git-hooks"]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "94a9c517b6fa314d694ce040a6c9062b",
+    "content-hash": "143f786c3f400a8c2fee8b96dd2504c8",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/src/Composer/InstallHooksScript.php
+++ b/src/Composer/InstallHooksScript.php
@@ -11,20 +11,21 @@ class InstallHooksScript
     {
         $fs = new Filesystem();
 
-        $hook = 'pre-commit';
-        $hookPath = '.git/hooks/'.$hook;
+        $hookPath = '.git/hooks/pre-commit';
 
         if ($fs->exists($hookPath)) {
             $fs->remove([$hookPath]);
         }
 
+        $binDir = $event->getComposer()->getConfig()->get('bin-dir');
+
         $hookFile = <<<'HOOK'
 #!/bin/sh
 
-exec ./bin/php-git-hooks pre-commit
+exec %s/php-git-hooks pre-commit
 HOOK;
 
-        $fs->dumpFile($hookPath, $hookFile);
+        $fs->dumpFile($hookPath, sprintf($hookFile, $binDir));
         $fs->chmod($hookPath, 0775);
     }
 }


### PR DESCRIPTION
I needed to remove the composer hooks because in this particular case, the bin dir is not the same and I don't see a proper way to fix this. 

Fix #3.